### PR TITLE
Fixes extra parameter in getAltRefs

### DIFF
--- a/kibom/component.py
+++ b/kibom/component.py
@@ -569,7 +569,7 @@ class ComponentGroup():
 
         # Update 'global' fields
         if usealt:
-            self.fields[ColumnList.COL_REFERENCE] = self.getAltRefs(wrapN)
+            self.fields[ColumnList.COL_REFERENCE] = self.getAltRefs()
         else:
             self.fields[ColumnList.COL_REFERENCE] = self.getRefs()
 


### PR DESCRIPTION
This was introduced by SchrodingersGat/KiBoM#117
Is just a call that still use the removed option.
Was detected by the CI pipeline.