### PR TITLE
Do not report warnings about conflicts in `Config` field

### DIFF
--- a/kibom/component.py
+++ b/kibom/component.py
@@ -556,11 +556,12 @@ class ComponentGroup():
         elif fieldData.lower() in self.fields[field].lower():
             return
         else:
-            debug.warning("Field conflict: ({refs}) [{name}] : '{flds}' <- '{fld}'".format(
-                refs=self.getRefs(),
-                name=field,
-                flds=self.fields[field],
-                fld=fieldData).encode('utf-8'))
+            if field != self.prefs.configField:
+                debug.warning("Field conflict: ({refs}) [{name}] : '{flds}' <- '{fld}'".format(
+                    refs=self.getRefs(),
+                    name=field,
+                    flds=self.fields[field],
+                    fld=fieldData).encode('utf-8'))
             self.fields[field] += " " + fieldData
 
     def updateFields(self, usealt=False, wrapN=None):


### PR DESCRIPTION
When using variants the Config fields may be quite different between
components.
Reporting conflicts in Config generates noise.