### PR TITLE
Fix for various configuration details issues.

### DIFF
--- a/kibom/bom_writer.py
+++ b/kibom/bom_writer.py
@@ -47,7 +47,7 @@ def WriteBoM(filename, groups, net, headings=columns.ColumnList._COLUMNS_DEFAULT
         filename += ".csv"
 
     # Make a temporary copy of the output file
-    if prefs.backup is not False:
+    if prefs.backup:
         TmpFileCopy(filename, prefs.backup)
 
     ext = filename.split('.')[-1].lower()


### PR DESCRIPTION
- Added warning if boolean options aren't 0,1,yes,no,true,false
- `as_link` and `digikey_link`: avoid writing "False" boolean, which
  then is loaded as "False" string. Now using '' which is equivalent
  to False. (bool('') -> False). Introduced by me on
  SchrodingersGat/KiBoM#112 and SchrodingersGat/KiBoM#114.
- Put all SECTION_GENERAL options inside the already existing if.
- `backup` also made to default to '' instead of False for coherence.
- `hide_headers` and `hide_pcb_info` now support the same options as
  other booleans. Also write them as '0', not 'False' for coherence
  with all the other booleans.
- `board_variant` write as a string, not an array (bizarre
  ['default']" in created *bom.ini*)
- Add a checkStr method, to make it similar to checkInt and
  checkOption. Making the general options much more compact in the
  code.
- `output_file_name` and `variant_file_name_format` now use a more
  general fallback mechanism (fallback option is documented only for
  Python 3). Better than what I did in SchrodingersGat/KiBoM#121.